### PR TITLE
 jetbrains-styx: Document gradle wrapper so `./gradlew` works, ignore…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ target/
 node_modules/
 pnpm-lock.yaml
 
+# IDE files
+.idea
+
 # Built JS bundles
 docs/static/codemirror/
 docs/static/monaco/

--- a/editors/jetbrains-styx/.gitignore
+++ b/editors/jetbrains-styx/.gitignore
@@ -1,0 +1,6 @@
+/.gradle
+/gradle
+/gradlew.bat
+/gradlew
+/build
+/.intellijPlatform

--- a/editors/jetbrains-styx/README.md
+++ b/editors/jetbrains-styx/README.md
@@ -12,6 +12,7 @@ Coming soon.
 
 ```bash
 cd editors/jetbrains-styx
+gradle wrapper
 ./gradlew buildPlugin
 ```
 


### PR DESCRIPTION
… generated files