### PR TITLE
fix(go): correct compliance test and heredoc language hint handling

### DIFF
--- a/implementations/styx-go/compliance_test.go
+++ b/implementations/styx-go/compliance_test.go
@@ -129,7 +129,7 @@ func getGoOutput(content string) string {
 }
 
 func getRustOutput(t *testing.T, file string, styxCLI string) string {
-	cmd := exec.Command(styxCLI, "@tree", "--format", "sexp", file)
+	cmd := exec.Command(styxCLI, "tree", "--format", "sexp", file)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/implementations/styx-go/lexer.go
+++ b/implementations/styx-go/lexer.go
@@ -381,9 +381,6 @@ func (l *Lexer) readHeredoc(start int, hadWhitespace, hadNewline bool) (*Token, 
 		// Check for exact match (no indentation)
 		if lineStr == bareDelimiter {
 			result := text.String()
-			if strings.Contains(delimStr, ",") {
-				result = delimStr[len(bareDelimiter):] + "\n" + result
-			}
 			return &Token{TokenHeredoc, result, Span{start, l.bytePos}, hadWhitespace, hadNewline}, nil
 		}
 
@@ -393,9 +390,6 @@ func (l *Lexer) readHeredoc(start int, hadWhitespace, hadNewline bool) (*Token, 
 			indentLen := len(lineStr) - len(stripped)
 			// Dedent the content by stripping up to indentLen from each line
 			result := dedentHeredoc(text.String(), indentLen)
-			if strings.Contains(delimStr, ",") {
-				result = delimStr[len(bareDelimiter):] + "\n" + result
-			}
 			return &Token{TokenHeredoc, result, Span{start, l.bytePos}, hadWhitespace, hadNewline}, nil
 		}
 


### PR DESCRIPTION
## Summary

- Update Go compliance test to use `tree` instead of `@tree` for the styx CLI command (the `@` prefix was removed)
- Remove code that incorrectly included the language hint in heredoc content (e.g., `,rust\n` should not be part of the heredoc value - it's syntax metadata)

## Test plan

- [x] All 74 Go compliance tests pass
- [x] Full Rust test suite passes (402 tests)