### PR TITLE
fix(python): correct heredoc and trailing-gt handling

### DIFF
--- a/implementations/styx-py/styx/lexer.py
+++ b/implementations/styx-py/styx/lexer.py
@@ -296,8 +296,6 @@ class Lexer:
 
             # Check for exact match (no indentation)
             if line == bare_delimiter:
-                if "," in delimiter:
-                    text = delimiter[len(bare_delimiter) :] + "\n" + text
                 return Token(
                     TokenType.HEREDOC, text, Span(start, self.byte_pos), had_whitespace, had_newline
                 )
@@ -308,8 +306,6 @@ class Lexer:
                 indent_len = len(line) - len(stripped)
                 # Dedent the content by stripping up to indent_len from each line
                 result = self._dedent_heredoc(text, indent_len)
-                if "," in delimiter:
-                    result = delimiter[len(bare_delimiter) :] + "\n" + result
                 return Token(
                     TokenType.HEREDOC,
                     result,

--- a/implementations/styx-py/styx/parser.py
+++ b/implementations/styx-py/styx/parser.py
@@ -137,9 +137,9 @@ class Parser:
         while self._check(TokenType.COMMA):
             self._advance()
 
-        # Skip stray > tokens (can happen with `value>` where > has no following value)
-        while self._check(TokenType.GT):
-            self._advance()
+        # Stray > tokens without a value are an error
+        if self._check(TokenType.GT):
+            raise ParseError("expected a value", self.current.span)
 
         if self._check(TokenType.EOF, TokenType.RBRACE):
             return None
@@ -193,9 +193,9 @@ class Parser:
         while self._check(TokenType.COMMA):
             self._advance()
 
-        # Skip stray > tokens (can happen with `value>` where > has no following value)
-        while self._check(TokenType.GT):
-            self._advance()
+        # Stray > tokens without a value are an error
+        if self._check(TokenType.GT):
+            raise ParseError("expected a value", self.current.span)
 
         if self._check(TokenType.EOF, TokenType.RBRACE):
             return None


### PR DESCRIPTION
## Summary

- Remove code that incorrectly included language hint in heredoc content (e.g., `,rust\n` should not be part of the heredoc value - it's syntax metadata)
- Change parser to error on stray `>` tokens instead of silently skipping them (e.g., `key value>` should error, not parse as `key value`)

## Test plan

- [x] Python compliance output now matches the golden file exactly
- [x] Full Rust test suite passes (402 tests)