### PR TITLE
style: fix clippy warnings and formatting

### DIFF
--- a/crates/facet-styx/src/schema_gen.rs
+++ b/crates/facet-styx/src/schema_gen.rs
@@ -121,7 +121,10 @@ impl<T: facet_core::Facet<'static>> Default for GenerateSchema<T> {
 ///
 /// This function auto-generates the ID from the type name, which may not match
 /// your crate naming conventions.
-#[deprecated(since = "0.2.0", note = "use GenerateSchema::new().crate_name(...).version(...).cli(...).write(filename) instead")]
+#[deprecated(
+    since = "0.2.0",
+    note = "use GenerateSchema::new().crate_name(...).version(...).cli(...).write(filename) instead"
+)]
 pub fn generate_schema<T: facet_core::Facet<'static>>(filename: &str) {
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set - are you in a build script?");
     let path = Path::new(&out_dir).join(filename);

--- a/crates/styx-cli/src/main.rs
+++ b/crates/styx-cli/src/main.rs
@@ -298,13 +298,14 @@ fn run_file_mode(args: &[String]) -> Result<(), CliError> {
     }
 
     // Safety check: prevent -o pointing to same file as input
-    if let Some(ref output) = opts.output {
-        if opts.input != "-" && output != "-" && is_same_file(&opts.input, output) {
-            return Err(CliError::Usage(
-                "input and output are the same file\nhint: use --in-place to modify in place"
-                    .into(),
-            ));
-        }
+    if let Some(ref output) = opts.output
+        && opts.input != "-"
+        && output != "-"
+        && is_same_file(&opts.input, output)
+    {
+        return Err(CliError::Usage(
+            "input and output are the same file\nhint: use --in-place to modify in place".into(),
+        ));
     }
 
     // Read input
@@ -513,12 +514,8 @@ fn run_cst(file: &str) -> Result<(), CliError> {
 }
 
 fn run_extract(binary: &str) -> Result<(), CliError> {
-    let schemas = styx_embed::extract_schemas_from_file(Path::new(binary)).map_err(|e| {
-        CliError::Io(io::Error::new(
-            io::ErrorKind::Other,
-            format!("{binary}: {e}"),
-        ))
-    })?;
+    let schemas = styx_embed::extract_schemas_from_file(Path::new(binary))
+        .map_err(|e| CliError::Io(io::Error::other(format!("{binary}: {e}"))))?;
 
     if schemas.is_empty() {
         return Err(CliError::Usage(format!(
@@ -703,12 +700,12 @@ fn find_schema_declaration(value: &Value) -> Result<SchemaRef, CliError> {
             }
 
             if let Some(schema_obj) = entry.value.as_object() {
-                if let Some(cli_value) = schema_obj.get("cli") {
-                    if let Some(cli_name) = cli_value.as_str() {
-                        return Ok(SchemaRef::Embedded {
-                            cli: cli_name.to_string(),
-                        });
-                    }
+                if let Some(cli_value) = schema_obj.get("cli")
+                    && let Some(cli_name) = cli_value.as_str()
+                {
+                    return Ok(SchemaRef::Embedded {
+                        cli: cli_name.to_string(),
+                    });
                 }
                 return Err(CliError::Validation(
                     "@schema directive must have a 'cli' field with the binary name".into(),

--- a/crates/styx-embed-macros/src/lib.rs
+++ b/crates/styx-embed-macros/src/lib.rs
@@ -41,14 +41,14 @@ fn parse_string_literal(lit: &unsynn::Literal) -> Option<String> {
     let s = lit.to_string();
 
     // Raw string: r#"..."# or r"..."
-    if s.starts_with("r") {
-        // Find the opening quote pattern (r, r#, r##, etc.)
-        let hash_count = s[1..].chars().take_while(|&c| c == '#').count();
-        let prefix_len = 1 + hash_count + 1; // 'r' + hashes + '"'
+    if let Some(after_r) = s.strip_prefix("r") {
+        // Find the opening quote pattern (r#, r##, etc.)
+        let hash_count = after_r.chars().take_while(|&c| c == '#').count();
+        let prefix_len = hash_count + 1; // hashes + '"'
         let suffix_len = 1 + hash_count; // '"' + hashes
 
-        if s.len() >= prefix_len + suffix_len {
-            return Some(s[prefix_len..s.len() - suffix_len].to_string());
+        if after_r.len() >= prefix_len + suffix_len {
+            return Some(after_r[prefix_len..after_r.len() - suffix_len].to_string());
         }
     }
 
@@ -143,7 +143,7 @@ pub fn embed_inline(input: TokenStream) -> TokenStream {
         Err(e) => {
             return format!("compile_error!(\"expected string literals: {e}\")")
                 .parse()
-                .unwrap()
+                .unwrap();
         }
     };
 
@@ -155,7 +155,7 @@ pub fn embed_inline(input: TokenStream) -> TokenStream {
             None => {
                 return "compile_error!(\"expected string literal\")"
                     .parse()
-                    .unwrap()
+                    .unwrap();
             }
         }
     }
@@ -196,7 +196,7 @@ pub fn embed_file(input: TokenStream) -> TokenStream {
         Err(e) => {
             return format!("compile_error!(\"expected file path string: {e}\")")
                 .parse()
-                .unwrap()
+                .unwrap();
         }
     };
 
@@ -205,7 +205,7 @@ pub fn embed_file(input: TokenStream) -> TokenStream {
         None => {
             return "compile_error!(\"expected string literal for file path\")"
                 .parse()
-                .unwrap()
+                .unwrap();
         }
     };
 
@@ -215,7 +215,7 @@ pub fn embed_file(input: TokenStream) -> TokenStream {
         Err(e) => {
             return format!("compile_error!(\"failed to read {}: {}\")", path, e)
                 .parse()
-                .unwrap()
+                .unwrap();
         }
     };
 
@@ -242,7 +242,7 @@ pub fn embed_files(input: TokenStream) -> TokenStream {
         Err(e) => {
             return format!("compile_error!(\"expected file path strings: {e}\")")
                 .parse()
-                .unwrap()
+                .unwrap();
         }
     };
 
@@ -254,7 +254,7 @@ pub fn embed_files(input: TokenStream) -> TokenStream {
             None => {
                 return "compile_error!(\"expected string literal for file path\")"
                     .parse()
-                    .unwrap()
+                    .unwrap();
             }
         };
 
@@ -263,7 +263,7 @@ pub fn embed_files(input: TokenStream) -> TokenStream {
             Err(e) => {
                 return format!("compile_error!(\"failed to read {}: {}\")", path, e)
                     .parse()
-                    .unwrap()
+                    .unwrap();
             }
         }
     }
@@ -301,7 +301,7 @@ pub fn embed_outdir_file(input: TokenStream) -> TokenStream {
         Err(e) => {
             return format!("compile_error!(\"expected filename string: {e}\")")
                 .parse()
-                .unwrap()
+                .unwrap();
         }
     };
 
@@ -310,7 +310,7 @@ pub fn embed_outdir_file(input: TokenStream) -> TokenStream {
         None => {
             return "compile_error!(\"expected string literal for filename\")"
                 .parse()
-                .unwrap()
+                .unwrap();
         }
     };
 
@@ -334,7 +334,7 @@ pub fn embed_outdir_file(input: TokenStream) -> TokenStream {
         Err(e) => {
             return format!("compile_error!(\"failed to read {}: {}\")", path_str, e)
                 .parse()
-                .unwrap()
+                .unwrap();
         }
     };
 

--- a/crates/styx-embed/examples/roundtrip.rs
+++ b/crates/styx-embed/examples/roundtrip.rs
@@ -5,7 +5,8 @@
 use styx_embed::extract_schemas_from_file;
 
 // Embed the schema at compile time using inline string
-styx_embed::embed_inline!(r#"meta {
+styx_embed::embed_inline!(
+    r#"meta {
   id example-config
   version 1.0.0
   description "Example schema for testing embedding"
@@ -18,7 +19,8 @@ schema {
     debug @optional(@bool)
   }
 }
-"#);
+"#
+);
 
 fn main() {
     // Get path to our own executable

--- a/crates/styx-embed/src/lib.rs
+++ b/crates/styx-embed/src/lib.rs
@@ -262,10 +262,11 @@ pub fn extract_schemas_from_object(data: &[u8]) -> Result<Vec<String>, ExtractEr
 
     // Try to parse as a known object format
     if let Ok(object) = Object::parse(data)
-        && let Some(section_data) = find_schema_section(&object, data) {
-            // Found the section - extract directly from it
-            return extract_schemas(section_data);
-        }
+        && let Some(section_data) = find_schema_section(&object, data)
+    {
+        // Found the section - extract directly from it
+        return extract_schemas(section_data);
+    }
 
     // Fall back to magic byte scanning for unknown formats or missing section
     extract_schemas(data)
@@ -287,13 +288,14 @@ fn find_schema_section<'a>(object: &goblin::Object, data: &'a [u8]) -> Option<&'
 fn find_elf_section<'a>(elf: &goblin::elf::Elf, data: &'a [u8]) -> Option<&'a [u8]> {
     for section in &elf.section_headers {
         if let Some(name) = elf.shdr_strtab.get_at(section.sh_name)
-            && name == section_names::ELF {
-                let start = section.sh_offset as usize;
-                let size = section.sh_size as usize;
-                if start + size <= data.len() {
-                    return Some(&data[start..start + size]);
-                }
+            && name == section_names::ELF
+        {
+            let start = section.sh_offset as usize;
+            let size = section.sh_size as usize;
+            if start + size <= data.len() {
+                return Some(&data[start..start + size]);
             }
+        }
     }
     None
 }
@@ -313,9 +315,10 @@ fn find_macho_section<'a>(mach: &goblin::mach::Mach, data: &'a [u8]) -> Option<&
                     let arch_data = &data[start..start + size];
                     if let Ok(goblin::Object::Mach(Mach::Binary(macho))) =
                         goblin::Object::parse(arch_data)
-                        && let Some(section) = find_macho_section_in_binary(&macho, arch_data) {
-                            return Some(section);
-                        }
+                        && let Some(section) = find_macho_section_in_binary(&macho, arch_data)
+                    {
+                        return Some(section);
+                    }
                 }
             }
             None
@@ -330,18 +333,20 @@ fn find_macho_section_in_binary<'a>(
 ) -> Option<&'a [u8]> {
     for segment in &macho.segments {
         if let Ok(name) = segment.name()
-            && name == section_names::MACHO_SEGMENT {
-                for (section, _section_data) in segment.sections().ok()? {
-                    if let Ok(sect_name) = section.name()
-                        && sect_name == section_names::MACHO_SECTION {
-                            let start = section.offset as usize;
-                            let size = section.size as usize;
-                            if start + size <= data.len() {
-                                return Some(&data[start..start + size]);
-                            }
-                        }
+            && name == section_names::MACHO_SEGMENT
+        {
+            for (section, _section_data) in segment.sections().ok()? {
+                if let Ok(sect_name) = section.name()
+                    && sect_name == section_names::MACHO_SECTION
+                {
+                    let start = section.offset as usize;
+                    let size = section.size as usize;
+                    if start + size <= data.len() {
+                        return Some(&data[start..start + size]);
+                    }
                 }
             }
+        }
     }
     None
 }
@@ -350,13 +355,14 @@ fn find_macho_section_in_binary<'a>(
 fn find_pe_section<'a>(pe: &goblin::pe::PE, data: &'a [u8]) -> Option<&'a [u8]> {
     for section in &pe.sections {
         if let Ok(name) = section.name()
-            && name == section_names::PE {
-                let start = section.pointer_to_raw_data as usize;
-                let size = section.size_of_raw_data as usize;
-                if start + size <= data.len() {
-                    return Some(&data[start..start + size]);
-                }
+            && name == section_names::PE
+        {
+            let start = section.pointer_to_raw_data as usize;
+            let size = section.size_of_raw_data as usize;
+            if start + size <= data.len() {
+                return Some(&data[start..start + size]);
             }
+        }
     }
     None
 }

--- a/crates/styx-lsp/src/schema_validation.rs
+++ b/crates/styx-lsp/src/schema_validation.rs
@@ -62,14 +62,13 @@ pub fn find_schema_declaration(value: &Value) -> Option<SchemaRef> {
             }
 
             // @schema {id ..., cli ...}
-            if let Some(schema_obj) = entry.value.as_object() {
-                if let Some(cli_value) = schema_obj.get("cli") {
-                    if let Some(cli_name) = cli_value.as_str() {
-                        return Some(SchemaRef::Embedded {
-                            cli: cli_name.to_string(),
-                        });
-                    }
-                }
+            if let Some(schema_obj) = entry.value.as_object()
+                && let Some(cli_value) = schema_obj.get("cli")
+                && let Some(cli_name) = cli_value.as_str()
+            {
+                return Some(SchemaRef::Embedded {
+                    cli: cli_name.to_string(),
+                });
             }
         }
     }

--- a/crates/styx-lsp/src/semantic_tokens.rs
+++ b/crates/styx-lsp/src/semantic_tokens.rs
@@ -108,7 +108,12 @@ pub fn compute_semantic_tokens(parse: &Parse) -> Vec<SemanticToken> {
     let mut raw_tokens = Vec::new();
 
     // Walk the CST and emit tokens
-    walk_node(&parse.syntax(), &content, &mut raw_tokens, WalkContext::default());
+    walk_node(
+        &parse.syntax(),
+        &content,
+        &mut raw_tokens,
+        WalkContext::default(),
+    );
 
     // Sort tokens by position
     raw_tokens.sort_by(|a, b| a.line.cmp(&b.line).then(a.start_char.cmp(&b.start_char)));
@@ -276,22 +281,28 @@ fn collect_key_tokens(node: &SyntaxNode, content: &str, tokens: &mut Vec<RawToke
                     for tag_child in child_node.children_with_tokens() {
                         if let Some(token) = tag_child.as_token() {
                             if token.kind() == SyntaxKind::AT {
-                                add_token_from_syntax(tokens, content, token, TokenType::Operator, 0);
+                                add_token_from_syntax(
+                                    tokens,
+                                    content,
+                                    token,
+                                    TokenType::Operator,
+                                    0,
+                                );
                             }
-                        } else if let Some(tag_node) = tag_child.as_node() {
-                            if tag_node.kind() == SyntaxKind::TAG_NAME {
-                                for t in tag_node.children_with_tokens() {
-                                    if let Some(token) = t.as_token()
-                                        && is_scalar_token(token.kind())
-                                    {
-                                        add_token_from_syntax(
-                                            tokens,
-                                            content,
-                                            token,
-                                            TokenType::Type,
-                                            0,
-                                        );
-                                    }
+                        } else if let Some(tag_node) = tag_child.as_node()
+                            && tag_node.kind() == SyntaxKind::TAG_NAME
+                        {
+                            for t in tag_node.children_with_tokens() {
+                                if let Some(token) = t.as_token()
+                                    && is_scalar_token(token.kind())
+                                {
+                                    add_token_from_syntax(
+                                        tokens,
+                                        content,
+                                        token,
+                                        TokenType::Type,
+                                        0,
+                                    );
                                 }
                             }
                         }
@@ -330,7 +341,13 @@ fn collect_key_tokens_as_values(node: &SyntaxNode, content: &str, tokens: &mut V
                     for tag_child in child_node.children_with_tokens() {
                         if let Some(token) = tag_child.as_token() {
                             if token.kind() == SyntaxKind::AT {
-                                add_token_from_syntax(tokens, content, token, TokenType::Operator, 0);
+                                add_token_from_syntax(
+                                    tokens,
+                                    content,
+                                    token,
+                                    TokenType::Operator,
+                                    0,
+                                );
                             }
                         } else if let Some(tag_node) = tag_child.as_node() {
                             if tag_node.kind() == SyntaxKind::TAG_NAME {
@@ -531,7 +548,10 @@ mod tests {
         assert_eq!(tokens.len(), 1);
         assert_eq!(tokens[0].token_type, TokenType::Comment);
         // Documentation modifier is bit 0
-        assert_eq!(tokens[0].modifiers, 1 << TokenModifier::Documentation as u32);
+        assert_eq!(
+            tokens[0].modifiers,
+            1 << TokenModifier::Documentation as u32
+        );
         assert_eq!(tokens[0].length, 25);
     }
 

--- a/crates/styx-lsp/src/server.rs
+++ b/crates/styx-lsp/src/server.rs
@@ -1943,10 +1943,10 @@ fn navigate_schema_path<'a>(value: &'a Value, path: &[String]) -> Option<&'a Val
         }
 
         // Check unit key (root definition)
-        if entry.key.is_unit() {
-            if let Some(result) = navigate_schema_path(&entry.value, path) {
-                return Some(result);
-            }
+        if entry.key.is_unit()
+            && let Some(result) = navigate_schema_path(&entry.value, path)
+        {
+            return Some(result);
         }
     }
 
@@ -1956,27 +1956,27 @@ fn navigate_schema_path<'a>(value: &'a Value, path: &[String]) -> Option<&'a Val
 /// Unwrap type wrappers like @optional(...) to get to the inner type
 fn unwrap_type_wrappers(value: &Value) -> &Value {
     // Check for @optional, @default, etc. which wrap the actual type
-    if let Some(tag) = value.tag_name() {
-        if matches!(tag, "optional" | "default" | "deprecated") {
-            // The inner type is in the payload
-            match &value.payload {
-                // @optional(@object{...}) - parenthesized, so it's a sequence with one item
-                Some(styx_tree::Payload::Sequence(seq)) => {
-                    if let Some(first) = seq.items.first() {
-                        return unwrap_type_wrappers(first);
-                    }
+    if let Some(tag) = value.tag_name()
+        && matches!(tag, "optional" | "default" | "deprecated")
+    {
+        // The inner type is in the payload
+        match &value.payload {
+            // @optional(@object{...}) - parenthesized, so it's a sequence with one item
+            Some(styx_tree::Payload::Sequence(seq)) => {
+                if let Some(first) = seq.items.first() {
+                    return unwrap_type_wrappers(first);
                 }
-                // @optional @object{...} - the object is the payload directly
-                Some(styx_tree::Payload::Object(obj)) => {
-                    // Check for unit entry pattern
-                    for entry in &obj.entries {
-                        if entry.key.is_unit() {
-                            return unwrap_type_wrappers(&entry.value);
-                        }
-                    }
-                }
-                _ => {}
             }
+            // @optional @object{...} - the object is the payload directly
+            Some(styx_tree::Payload::Object(obj)) => {
+                // Check for unit entry pattern
+                for entry in &obj.entries {
+                    if entry.key.is_unit() {
+                        return unwrap_type_wrappers(&entry.value);
+                    }
+                }
+            }
+            _ => {}
         }
     }
     value

--- a/crates/styx-parse/src/lexer.rs
+++ b/crates/styx-parse/src/lexer.rs
@@ -341,21 +341,21 @@ impl<'src> Lexer<'src> {
         if self.peek() == Some(',') {
             self.advance(); // consume ','
             // First char must be lowercase letter
-            if let Some(c) = self.peek() {
-                if c.is_ascii_lowercase() {
-                    self.advance();
-                    // Rest: lowercase, digit, underscore, dot, hyphen
-                    while let Some(c) = self.peek() {
-                        if c.is_ascii_lowercase()
-                            || c.is_ascii_digit()
-                            || c == '_'
-                            || c == '.'
-                            || c == '-'
-                        {
-                            self.advance();
-                        } else {
-                            break;
-                        }
+            if let Some(c) = self.peek()
+                && c.is_ascii_lowercase()
+            {
+                self.advance();
+                // Rest: lowercase, digit, underscore, dot, hyphen
+                while let Some(c) = self.peek() {
+                    if c.is_ascii_lowercase()
+                        || c.is_ascii_digit()
+                        || c == '_'
+                        || c == '.'
+                        || c == '-'
+                    {
+                        self.advance();
+                    } else {
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Use `strip_prefix` instead of manual prefix handling in styx-embed-macros
- Collapse nested if statements using let-chains across styx-parse, styx-lsp, and styx-cli
- Use `io::Error::other()` instead of `io::Error::new()` in styx-cli
- Apply `cargo fmt` formatting fixes across multiple crates

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-features --all-targets` passes with no warnings
- [x] All 402 tests pass