### PR TITLE
feat(editors): add syntax highlighting for heredoc language hints

### DIFF
--- a/crates/tree-sitter-styx/queries/highlights.scm
+++ b/crates/tree-sitter-styx/queries/highlights.scm
@@ -14,6 +14,9 @@
 (raw_scalar) @string
 (heredoc) @string
 
+; Heredoc language hint (metadata)
+(heredoc_lang) @label
+
 ; Unit value
 (unit) @constant.builtin
 

--- a/editors/nvim-styx/queries/styx/highlights.scm
+++ b/editors/nvim-styx/queries/styx/highlights.scm
@@ -13,6 +13,9 @@
 (raw_scalar) @string
 (heredoc) @string
 
+; Heredoc language hint (metadata)
+(heredoc_lang) @label
+
 ; Unit value
 (unit) @constant.builtin
 

--- a/editors/zed-styx/languages/styx/highlights.scm
+++ b/editors/zed-styx/languages/styx/highlights.scm
@@ -14,6 +14,9 @@
 (raw_scalar) @string
 (heredoc) @string
 
+; Heredoc language hint (metadata)
+(heredoc_lang) @label
+
 ; Unit value
 (unit) @constant.builtin
 


### PR DESCRIPTION
## Summary

Add syntax highlighting for heredoc language hints across all editor configurations. The language hint (e.g., `json` in `<<json` heredocs) is now highlighted with the `@label` capture, making it visually distinct from the heredoc content.

## Changes

- Add `heredoc_lang` highlighting rule to `crates/tree-sitter-styx/queries/highlights.scm`
- Add `heredoc_lang` highlighting rule to `editors/nvim-styx/queries/styx/highlights.scm`
- Add `heredoc_lang` highlighting rule to `editors/zed-styx/languages/styx/highlights.scm`

## Test plan

- Open a `.styx` file with heredocs containing language hints in Neovim or Zed
- Verify the language hint text is highlighted differently from the heredoc content