### PR TITLE
typo syntax fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ And so, tags are a natural way to _select_ a variant:
 ```styx
 alts (
     @no_payload@
-    @tuple_payload(3, 7)
+    @tuple_payload(3 7)
     @struct_payload{name Gisèle}
 )
 ```


### PR DESCRIPTION
was going through and testing out the examples and got a syntax error. spotted this typo

commit message was auto generated by AI. if that's important, I can rebase to change the message