### PR TITLE
Upgrade facet-styx to facet-format 0.44.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "facet-dessert"
-version = "0.44.1"
+version = "0.44.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64092a2ececf59431c1b98561ba12e308c20185185fedc8c5396468e87573435"
+checksum = "0fb18a3e7ee90139051f679390662ae158439c1564b73b482676b9a3862d13c0"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "facet-format"
-version = "0.44.1"
+version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b93a20a96d7dc1ab469896487f26f5c467b5b28c0448b4419fe8497ed1c6e5c"
+checksum = "50e9bca089d254ef30bcb902566f7f8477b29a11cda26d5332bd584259af451c"
 dependencies = [
  "facet-core",
  "facet-dessert",
@@ -712,6 +712,7 @@ checksum = "2e87fefb7fabe10278980588bb13bcfde4faeda4b3c29ae83c3c66efe0cad1a5"
 dependencies = [
  "facet-core",
  "facet-reflect",
+ "strsim",
 ]
 
 [[package]]
@@ -735,6 +736,7 @@ dependencies = [
  "styx-testhelpers",
  "styx-tree",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ strip-ansi-escapes = "0.2"
 # Facet crates
 facet = { version = "0.44" }
 facet-core = { version = "0.44" }
-facet-format = { version = "0.44" }
+facet-format = { version = "0.44.6" }
 facet-reflect = { version = "0.44" }
 facet-testhelpers = { version = "0.44" }
 facet-json = { version = "0.44" }
@@ -84,3 +84,4 @@ lto = "thin"
 # facet-solver = { path = "../facet/facet-solver" }
 # facet-json = { path = "../facet/facet-json" }
 # facet-testhelpers = { path = "../facet/facet-testhelpers" }
+

--- a/crates/facet-styx/Cargo.toml
+++ b/crates/facet-styx/Cargo.toml
@@ -31,6 +31,7 @@ figue = { workspace = true, optional = true }
 [dev-dependencies]
 styx-testhelpers = { path = "../styx-testhelpers" }
 tracing.workspace = true
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 facet-testhelpers.workspace = true
 insta.workspace = true
 strip-ansi-escapes.workspace = true

--- a/crates/facet-styx/src/lib.rs
+++ b/crates/facet-styx/src/lib.rs
@@ -46,6 +46,8 @@ mod figue_format;
 #[cfg(test)]
 mod idempotency_test;
 #[cfg(test)]
+mod mixed_expr_test;
+#[cfg(test)]
 mod other_variant_test;
 mod parser;
 mod schema_error;

--- a/crates/facet-styx/src/mixed_expr_test.rs
+++ b/crates/facet-styx/src/mixed_expr_test.rs
@@ -1,0 +1,114 @@
+use std::collections::HashMap;
+use std::sync::Once;
+
+use facet::Facet;
+
+use crate::{Documented, from_str};
+
+fn init_tracing() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::from_default_env()
+                    .add_directive("facet_styx=trace".parse().unwrap())
+                    .add_directive("facet_format=trace".parse().unwrap()),
+            )
+            .with_test_writer()
+            .try_init();
+    });
+}
+
+#[derive(Facet, Debug, PartialEq)]
+#[facet(untagged)]
+#[repr(u8)]
+enum ExprPayload {
+    Scalar(String),
+    Seq(Vec<Expr>),
+    Object(ExprObject),
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct ExprObject {
+    #[facet(flatten)]
+    fields: HashMap<Documented<String>, Expr>,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+#[facet(rename_all = "snake_case")]
+#[repr(u8)]
+enum Expr {
+    Template(Box<TemplateDecl>),
+    Regex(Vec<Expr>),
+    #[facet(rename = "Any")]
+    Any,
+    #[facet(other)]
+    Other {
+        #[facet(tag)]
+        tag: Option<String>,
+        #[facet(content)]
+        content: Option<ExprPayload>,
+    },
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct TemplateDecl {
+    params: Vec<Expr>,
+    body: Box<TemplateBody>,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct TemplateBody {
+    syntax: Box<Expr>,
+    highlight: Option<String>,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct Doc {
+    v: Expr,
+}
+
+#[test]
+fn mixed_expr_accepts_any_tag() {
+    init_tracing();
+    let parsed: Doc = from_str("v @Any").unwrap();
+    assert_eq!(parsed.v, Expr::Any);
+}
+
+#[test]
+fn mixed_expr_accepts_sequence_with_object_binding() {
+    init_tracing();
+    let parsed: Doc = from_str("v ({text @Any})").unwrap();
+    match parsed.v {
+        Expr::Other {
+            tag: None,
+            content: Some(ExprPayload::Seq(items)),
+        } => assert_eq!(items.len(), 1),
+        other => panic!("expected untagged sequence, got {other:?}"),
+    }
+}
+
+#[test]
+fn mixed_expr_accepts_template_tagged_struct() {
+    init_tracing();
+    let parsed: Doc = from_str(
+        r#"
+v @template{
+    params ({text @Any})
+    body {
+        syntax text
+        highlight keyword
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    match parsed.v {
+        Expr::Template(template) => {
+            assert_eq!(template.params.len(), 1);
+            assert_eq!(template.body.highlight.as_deref(), Some("keyword"));
+        }
+        other => panic!("expected template, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Upgrade `facet-styx` to `facet-format 0.44.6` and add focused regression coverage for mixed expression shapes used by schema-like Styx documents.

## What changed

- bump workspace `facet-format` dependency to `0.44.6`
- update `Cargo.lock`
- add `mixed_expr_test.rs`
- register that test module in `facet-styx`
- add `tracing-subscriber` as a dev-dependency for focused test tracing

## Why

`facet-format 0.44.6` includes the externally tagged enum fallback fix needed for expression-like enums that mix:

- bare tags like `@Any`
- bare sequences like `({text @Any})`
- tagged structs like `@template{ ... }`

These are the forms the new Kajit schema work needs `facet-styx` to accept.

## Validation

```bash
cargo nextest run -p facet-styx \
  mixed_expr_accepts_any_tag \
  mixed_expr_accepts_sequence_with_object_binding \
  mixed_expr_accepts_template_tagged_struct
```

All three pass with `facet-format 0.44.6`.
