### PR TITLE
chore: migrate from roam to vox, bump facet to 0.46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,24 +538,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aa60b7d3d49d30f477f9490b7fc3ce42009b5b626b625b0356742884c493a11"
 dependencies = [
  "autocfg",
- "facet-core",
- "facet-macros",
- "facet-reflect",
+ "facet-core 0.44.3",
+ "facet-macros 0.44.3",
+]
+
+[[package]]
+name = "facet"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ddcfe946b050b8aa99d2cf4e0b56e1437fcec41de190aebb9ff621d95b82157"
+dependencies = [
+ "autocfg",
+ "facet-core 0.46.0",
+ "facet-macros 0.46.0",
+ "facet-reflect 0.46.0",
 ]
 
 [[package]]
 name = "facet-cargo-toml"
-version = "0.44.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1dfe5ee67dafa3ee39af19b47e0da41337f72e7e0e841f4400dec966b8cafa8"
+checksum = "75c548f3af86ce3275646215d2a161017d419da8c14a5e0111d5b5adce9fa66f"
 dependencies = [
  "camino",
- "facet",
+ "facet 0.46.0",
  "facet-error",
- "facet-format",
- "facet-reflect",
+ "facet-reflect 0.46.0",
  "facet-toml",
- "facet-value",
+ "facet-value 0.46.0",
+]
+
+[[package]]
+name = "facet-cbor"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a682973dcf51a2efdded0abde90732e4b45eb2aec15d4e0d6a6fc640fa9dbd60"
+dependencies = [
+ "facet 0.46.0",
+ "facet-core 0.46.0",
+ "facet-reflect 0.46.0",
 ]
 
 [[package]]
@@ -563,6 +584,18 @@ name = "facet-core"
 version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f9ee47507f15c18243a8cba3b2a85b71176173f0097e9164a54dd4e4e3e4ce"
+dependencies = [
+ "autocfg",
+ "const-fnv1a-hash",
+ "iddqd",
+ "impls",
+]
+
+[[package]]
+name = "facet-core"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b18251d9fd8e27c85ba879c75cb2f92fdd5f1e43c17fedc3a40faadcc3fa2a99"
 dependencies = [
  "autocfg",
  "camino",
@@ -578,17 +611,27 @@ version = "0.44.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fb18a3e7ee90139051f679390662ae158439c1564b73b482676b9a3862d13c0"
 dependencies = [
- "facet-core",
- "facet-reflect",
+ "facet-core 0.44.3",
+ "facet-reflect 0.44.3",
+]
+
+[[package]]
+name = "facet-dessert"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4505ec8ef086d776fd99b86fb17e3d1c711188d27aa72845e64a30146226e3b"
+dependencies = [
+ "facet-core 0.46.0",
+ "facet-reflect 0.46.0",
 ]
 
 [[package]]
 name = "facet-error"
-version = "0.44.3"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ad09f4efc4d87eaa1122dbd194caac256ce0c4002b799ffe3f346cdc1ad01"
+checksum = "1056c5e471df1fa28badf53743dca14e341709f4dcc3cb5acba64e39e4185369"
 dependencies = [
- "facet",
+ "facet 0.46.0",
 ]
 
 [[package]]
@@ -597,11 +640,24 @@ version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50e9bca089d254ef30bcb902566f7f8477b29a11cda26d5332bd584259af451c"
 dependencies = [
- "facet-core",
- "facet-dessert",
- "facet-path",
- "facet-reflect",
- "facet-solver",
+ "facet-core 0.44.3",
+ "facet-dessert 0.44.5",
+ "facet-path 0.44.3",
+ "facet-reflect 0.44.3",
+ "facet-solver 0.44.3",
+]
+
+[[package]]
+name = "facet-format"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5cd7279699433cea9d921165ebc6fad0526574e6e8e6d1144b3bc5136e8c3a"
+dependencies = [
+ "facet-core 0.46.0",
+ "facet-dessert 0.46.0",
+ "facet-path 0.46.0",
+ "facet-reflect 0.46.0",
+ "facet-solver 0.46.0",
  "tracing",
 ]
 
@@ -611,11 +667,23 @@ version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dc7a1b6408721dfef48541539b8958a43940bcad5f312f9a691ee3f5ff44465"
 dependencies = [
- "facet",
- "facet-core",
- "facet-format",
- "facet-reflect",
+ "facet 0.44.3",
+ "facet-core 0.44.3",
+ "facet-format 0.44.6",
+ "facet-reflect 0.44.3",
  "memchr",
+]
+
+[[package]]
+name = "facet-json"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5347e8a3788ab46119434c8fa011a49151c7c2d789bc50d0cfa914b878948593"
+dependencies = [
+ "facet 0.46.0",
+ "facet-core 0.46.0",
+ "facet-format 0.47.0",
+ "facet-reflect 0.46.0",
 ]
 
 [[package]]
@@ -624,7 +692,18 @@ version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e77becc35b3b3008e7b3ef23356954e46561177316aff0a92c73fc6ddb2a15a0"
 dependencies = [
- "facet-macro-types",
+ "facet-macro-types 0.44.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "facet-macro-parse"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f7d6b0fbbd7536883a30738d903e8aee8f76e7ee1a6ff8ea37cd16366a8e63"
+dependencies = [
+ "facet-macro-types 0.46.0",
  "proc-macro2",
  "quote",
 ]
@@ -641,12 +720,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-macro-types"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7121a5798fdc2e805121519e7c89be8e9a3e68460ac41ef3a3c83f7627713b79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unsynn",
+]
+
+[[package]]
 name = "facet-macros"
 version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3a7015e119aa043740dc8aee6b1b70e26b6616e1701b329496bf04990f44133"
 dependencies = [
- "facet-macros-impl",
+ "facet-macros-impl 0.44.3",
+]
+
+[[package]]
+name = "facet-macros"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1db2d8fa23c6605ba449df4cd0f7426a6fcce1fc4f620052c4d5d1ffd57653"
+dependencies = [
+ "facet-macros-impl 0.46.0",
 ]
 
 [[package]]
@@ -655,8 +754,22 @@ version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb5e6f6cc64210ab12aa625b014db78d34d6a3b63d1011382c141518a1e1f78"
 dependencies = [
- "facet-macro-parse",
- "facet-macro-types",
+ "facet-macro-parse 0.44.3",
+ "facet-macro-types 0.44.3",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "unsynn",
+]
+
+[[package]]
+name = "facet-macros-impl"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9853c5973e794ce3fc2d7cec37e2103264001ce351008a623959d434974ab6a"
+dependencies = [
+ "facet-macro-parse 0.46.0",
+ "facet-macro-types 0.46.0",
  "proc-macro2",
  "quote",
  "strsim",
@@ -669,32 +782,40 @@ version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e7b83cb0de7c00d6e76f08d36b047d6cb9efc39e10744dbcf7a4a5a19c4903"
 dependencies = [
- "facet-core",
+ "facet-core 0.44.3",
+]
+
+[[package]]
+name = "facet-path"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b06a8220cc524692f203a92b6318adf96a418e32352abc0ebc7cc5dc91232fa"
+dependencies = [
+ "facet-core 0.46.0",
 ]
 
 [[package]]
 name = "facet-postcard"
-version = "0.44.6"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c903b79cc89428f035e2d010a2d2d5046e08856f5b1360733c2a44b7830d4a33"
+checksum = "f714b1bab22177fd4c9ad0313cd03d13120c51b29df427aad15181dfea86a4d5"
 dependencies = [
- "camino",
- "facet-core",
- "facet-format",
- "facet-path",
- "facet-reflect",
- "facet-value",
+ "facet-core 0.46.0",
+ "facet-format 0.47.0",
+ "facet-path 0.46.0",
+ "facet-reflect 0.46.0",
+ "facet-value 0.46.0",
  "tracing",
 ]
 
 [[package]]
 name = "facet-pretty"
-version = "0.44.4"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b93416595a402722978717593f38b3d51ab17b5cc1d914305b1758f02651ead"
+checksum = "bf24a4157766d6c7b867d74cb11921125b0c902805b6b812990e878780479c48"
 dependencies = [
- "facet-core",
- "facet-reflect",
+ "facet-core 0.46.0",
+ "facet-reflect 0.46.0",
  "owo-colors",
 ]
 
@@ -704,9 +825,21 @@ version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9cc255bd928399489868fdddec09e69073d622432cc2b52cfa3c3a5d811305c"
 dependencies = [
- "facet-core",
- "facet-path",
+ "facet-core 0.44.3",
+ "facet-path 0.44.3",
  "hashbrown 0.16.1",
+ "smallvec 2.0.0-alpha.12",
+]
+
+[[package]]
+name = "facet-reflect"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa7e0761e33cca57643d82c0ed37cc6e66f23d6a68448280b91e9db0c9a9ec26"
+dependencies = [
+ "facet-core 0.46.0",
+ "facet-path 0.46.0",
+ "hashbrown 0.17.0",
  "regex",
  "smallvec 2.0.0-alpha.12",
  "tracing",
@@ -718,8 +851,19 @@ version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4d2427360875510d60267f4bb132f47aa4f5714896be9ca11c516f14542118d"
 dependencies = [
- "facet-core",
- "facet-reflect",
+ "facet-core 0.44.3",
+ "facet-reflect 0.44.3",
+ "strsim",
+]
+
+[[package]]
+name = "facet-solver"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc93ef9aeba0a6e9e280b0c015a2d82e1b0664624aaf8b920dc691c0990b8e6a"
+dependencies = [
+ "facet-core 0.46.0",
+ "facet-reflect 0.46.0",
  "strsim",
 ]
 
@@ -728,10 +872,10 @@ name = "facet-styx"
 version = "3.0.1"
 dependencies = [
  "ariadne",
- "facet",
- "facet-core",
- "facet-format",
- "facet-reflect",
+ "facet 0.46.0",
+ "facet-core 0.46.0",
+ "facet-format 0.47.0",
+ "facet-reflect 0.46.0",
  "facet-testhelpers",
  "figue",
  "indexmap",
@@ -749,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "facet-testhelpers"
-version = "0.44.3"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9003d5bede62269bdc9d71708ab5c686e590a2d20aeb2efa1ba7c49e43651c9a"
+checksum = "90625e0a7ace8eec9c6d4012a8dd31bde908bb11d8f4a0199343bdd1b75bfefc"
 dependencies = [
  "color-backtrace",
  "facet-testhelpers-macros",
@@ -762,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "facet-testhelpers-macros"
-version = "0.44.3"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6e17dfa5fc4da066dbf46244a72e4e3233c901914b8d979f12a3967649b859"
+checksum = "7e7b153a74ca10271cbbe82e354424ace219806a20f7d0d53580b6b9fa04a2d7"
 dependencies = [
  "quote",
  "unsynn",
@@ -772,13 +916,13 @@ dependencies = [
 
 [[package]]
 name = "facet-toml"
-version = "0.44.6"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0da230f77d4c948580af7ee7d8c035c15bf1a22deb38ca5eb164c1d104e970b"
+checksum = "e0209891dced78e1cbdb0fa0f4d524ab1945ded950bee6410d712d10d1a61a6e"
 dependencies = [
- "facet-core",
- "facet-format",
- "facet-reflect",
+ "facet-core 0.46.0",
+ "facet-format 0.47.0",
+ "facet-reflect 0.46.0",
  "toml_parser",
 ]
 
@@ -788,9 +932,21 @@ version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af6a6e316fa579d1058202829960da995a154daab5e2d9f8f770a979d54ee271"
 dependencies = [
- "facet-core",
- "facet-format",
- "facet-reflect",
+ "facet-core 0.44.3",
+ "facet-format 0.44.6",
+ "facet-reflect 0.44.3",
+ "indexmap",
+]
+
+[[package]]
+name = "facet-value"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c61477bcef8cda3ba1082f25ad69569792214f9d430671afb32e9cdedbce6d7"
+dependencies = [
+ "facet-core 0.46.0",
+ "facet-format 0.47.0",
+ "facet-reflect 0.46.0",
  "indexmap",
 ]
 
@@ -802,19 +958,19 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "figue"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ffdb761cf6aa5298efdef8ae22dac4057d492f85e1e7434864eb1ccbcfeae5"
+checksum = "1cf780a33f0c7d374475b515bb68518aae2d76769d4dd35885c0bb449780af65"
 dependencies = [
  "ariadne",
  "camino",
- "facet",
- "facet-core",
+ "facet 0.46.0",
+ "facet-core 0.46.0",
  "facet-error",
- "facet-format",
- "facet-json",
+ "facet-format 0.47.0",
+ "facet-json 0.46.0",
  "facet-pretty",
- "facet-reflect",
+ "facet-reflect 0.46.0",
  "figue-attrs",
  "heck 0.5.0",
  "indexmap",
@@ -828,11 +984,11 @@ dependencies = [
 
 [[package]]
 name = "figue-attrs"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95509cd6139af9c281d9e4f163db7fce0da7101102ac555e677937248437e58"
+checksum = "7adc97963c6278caf51a2bf452675d638b5c094026b3fb5cd7080765aedb5494"
 dependencies = [
- "facet",
+ "facet 0.46.0",
 ]
 
 [[package]]
@@ -984,11 +1140,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -998,10 +1152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1070,6 +1226,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1444,9 +1605,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568cc05b223c4c76247467e3bdaa7862f05c38d5c8f6e44198613880f90ecd98"
 dependencies = [
  "ctor",
- "facet",
- "facet-json",
- "facet-value",
+ "facet 0.44.3",
+ "facet-json 0.44.6",
+ "facet-value 0.44.6",
  "moire-trace-capture",
  "moire-trace-types",
  "moire-types",
@@ -1483,7 +1644,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ef6f98b447211257a517d101f0f5cf4300627cd6fd1c0c13ff53d157a872c9d"
 dependencies = [
- "facet",
+ "facet 0.44.3",
 ]
 
 [[package]]
@@ -1492,8 +1653,8 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "667b2fc41e30d3b0f7d0d29e978d3f473afaf0e0be355202eead317e35ace200"
 dependencies = [
- "facet",
- "facet-value",
+ "facet 0.44.3",
+ "facet-value 0.44.6",
  "moire-trace-types",
 ]
 
@@ -1519,8 +1680,8 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf0ec84eeb2e23a83339cf5edc9d5a3a9ec5849416bd4051951fba416ea3e0f7"
 dependencies = [
- "facet",
- "facet-json",
+ "facet 0.44.3",
+ "facet-json 0.44.6",
  "moire-trace-types",
  "moire-types",
 ]
@@ -1824,115 +1985,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "roam"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb8134b18b8735b239996b748307cfb208d84c245ed5595a6c2eece0e3c819a5"
-dependencies = [
- "facet",
- "facet-postcard",
- "roam-core",
- "roam-hash",
- "roam-service-macros",
- "roam-types",
-]
-
-[[package]]
-name = "roam-core"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736e8d8279a37ddce65b165ebd4c665b254885a159c75ff20b9379bff3d92626"
-dependencies = [
- "facet",
- "facet-core",
- "facet-error",
- "facet-format",
- "facet-postcard",
- "facet-reflect",
- "getrandom 0.3.4",
- "moire",
- "roam-types",
- "smallvec 1.15.1",
- "tokio",
- "tracing",
- "wasm-bindgen-futures",
- "zerocopy",
-]
-
-[[package]]
-name = "roam-hash"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926fac2289cbccf6100dd9fa733001a2999651cdeb6bea064320bac185dfa817"
-dependencies = [
- "blake3",
- "facet-core",
- "heck 0.5.0",
- "roam-types",
-]
-
-[[package]]
-name = "roam-macros-core"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5ac50c8954493d007a2a5541753fba33c605955abeb9221568ba0d160219e9"
-dependencies = [
- "facet-cargo-toml",
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "roam-macros-parse",
-]
-
-[[package]]
-name = "roam-macros-parse"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a453d67c29e4f4f34abdf0dbf56f2fce8f7e3fdbb2640df077237ac375cd866d"
-dependencies = [
- "proc-macro2",
- "unsynn",
-]
-
-[[package]]
-name = "roam-service-macros"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769c26280491ff451c3c7ac14ed7034237ae0e586d5d08297c4d43e9bea00797"
-dependencies = [
- "proc-macro2",
- "roam-macros-core",
-]
-
-[[package]]
-name = "roam-stream"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0751a9582404ea88c9eacbc679aefe2581a1e4867d384058c835ccd14ba32165"
-dependencies = [
- "moire",
- "roam-types",
- "tokio",
-]
-
-[[package]]
-name = "roam-types"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2c23550c346311389eea924816f06e7ed3a049d8bb437609ece1a312cabc67"
-dependencies = [
- "bitflags 2.11.0",
- "facet",
- "facet-core",
- "facet-path",
- "facet-postcard",
- "futures-channel",
- "smallvec 1.15.1",
- "structstruck",
- "tokio",
-]
-
-[[package]]
 name = "rowan"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2221,7 +2273,7 @@ dependencies = [
 name = "styx-cli"
 version = "3.0.1"
 dependencies = [
- "facet",
+ "facet 0.46.0",
  "facet-styx",
  "figue",
  "serde_json",
@@ -2241,7 +2293,7 @@ dependencies = [
 name = "styx-compat-tests"
 version = "3.0.0"
 dependencies = [
- "facet",
+ "facet 0.46.0",
  "facet-styx",
  "serde",
  "serde_styx",
@@ -2310,14 +2362,11 @@ version = "3.0.1"
 dependencies = [
  "dirs",
  "eyre",
- "facet",
+ "facet 0.46.0",
  "facet-styx",
  "futures",
  "glob",
  "hex",
- "roam-core",
- "roam-stream",
- "roam-types",
  "serde_json",
  "sha2",
  "styx-cst",
@@ -2331,6 +2380,7 @@ dependencies = [
  "tower-lsp",
  "tracing",
  "tracing-subscriber",
+ "vox",
  "which",
 ]
 
@@ -2338,16 +2388,16 @@ dependencies = [
 name = "styx-lsp-ext"
 version = "3.0.1"
 dependencies = [
- "facet",
- "roam",
+ "facet 0.46.0",
  "styx-tree",
+ "vox",
 ]
 
 [[package]]
 name = "styx-lsp-test-schema"
 version = "3.0.1"
 dependencies = [
- "facet",
+ "facet 0.46.0",
 ]
 
 [[package]]
@@ -2355,7 +2405,7 @@ name = "styx-parse"
 version = "3.0.1"
 dependencies = [
  "ariadne",
- "facet",
+ "facet 0.46.0",
  "facet-testhelpers",
  "similar",
  "styx-testhelpers",
@@ -2374,7 +2424,7 @@ dependencies = [
 name = "styx-tokenizer"
 version = "3.0.0"
 dependencies = [
- "facet",
+ "facet 0.46.0",
  "facet-testhelpers",
  "tracing",
 ]
@@ -2384,8 +2434,8 @@ name = "styx-tree"
 version = "3.0.1"
 dependencies = [
  "ariadne",
- "facet",
- "facet-json",
+ "facet 0.46.0",
+ "facet-json 0.46.0",
  "facet-postcard",
  "facet-testhelpers",
  "insta",
@@ -2849,6 +2899,142 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vox"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "550cb4261b59a868246e97c68d7fc904118e2f27d0ad6e806c031b83d7b1b292"
+dependencies = [
+ "facet 0.46.0",
+ "facet-pretty",
+ "facet-reflect 0.46.0",
+ "moire",
+ "tokio",
+ "tracing",
+ "vox-core",
+ "vox-postcard",
+ "vox-service-macros",
+ "vox-stream",
+ "vox-types",
+]
+
+[[package]]
+name = "vox-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7698d68fc31e8a107319f2f70fc22d7056c4bb0c4cac1b812e678b71d412c740"
+dependencies = [
+ "facet 0.46.0",
+ "facet-cbor",
+ "facet-core 0.46.0",
+ "facet-error",
+ "facet-reflect 0.46.0",
+ "getrandom 0.4.2",
+ "moire",
+ "smallvec 1.15.1",
+ "tokio",
+ "tracing",
+ "vox-postcard",
+ "vox-types",
+ "wasm-bindgen-futures",
+ "zerocopy",
+]
+
+[[package]]
+name = "vox-macros-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd15ed42ea2433772ccccf96c3398624d40b535a2f08b6216a93ad433863213"
+dependencies = [
+ "facet-cargo-toml",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "vox-macros-parse",
+]
+
+[[package]]
+name = "vox-macros-parse"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3971b499ce746324725d29d004081301d3544e9bbe462b16d9f721fe671322"
+dependencies = [
+ "proc-macro2",
+ "unsynn",
+]
+
+[[package]]
+name = "vox-postcard"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d8ccd6cfc2218d9ee0eedd66a2cab90caa2b2edd77b14598b2e95d582138d24"
+dependencies = [
+ "facet 0.46.0",
+ "facet-core 0.46.0",
+ "facet-reflect 0.46.0",
+ "vox-schema",
+]
+
+[[package]]
+name = "vox-schema"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "959c0e228704a4f33a79e46335abe19a16e048d604b96b4b6fd5a22cdc726e09"
+dependencies = [
+ "blake3",
+ "facet 0.46.0",
+ "facet-cbor",
+ "facet-core 0.46.0",
+ "indexmap",
+]
+
+[[package]]
+name = "vox-service-macros"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bfa731cd032bd4e6c93eded9132f9d85afb3059fff60e7058dbccb230ae52fa"
+dependencies = [
+ "proc-macro2",
+ "vox-macros-core",
+]
+
+[[package]]
+name = "vox-stream"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5499935a426cc81228e9b58aaecd5018f04812851a8fd3e5fa70b52f1eaa45f"
+dependencies = [
+ "libc",
+ "moire",
+ "tokio",
+ "vox-core",
+ "vox-types",
+]
+
+[[package]]
+name = "vox-types"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70e0805a3613451987220bc074fdbd51a986ffd0e8698e429e321c3121dcfc9"
+dependencies = [
+ "bitflags 2.11.0",
+ "blake3",
+ "facet 0.46.0",
+ "facet-cbor",
+ "facet-core 0.46.0",
+ "facet-path 0.46.0",
+ "facet-reflect 0.46.0",
+ "futures-channel",
+ "heck 0.5.0",
+ "indexmap",
+ "moire",
+ "smallvec 1.15.1",
+ "structstruck",
+ "tokio",
+ "vox-postcard",
+ "vox-schema",
+]
 
 [[package]]
 name = "vte"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,22 +14,19 @@ ariadne = "0.6"
 strip-ansi-escapes = "0.2"
 
 # Facet crates
-facet = { version = "0.44" }
-facet-core = { version = "0.44" }
-facet-format = { version = "0.44.6" }
-facet-reflect = { version = "0.44" }
-facet-testhelpers = { version = "0.44" }
-facet-json = { version = "0.44" }
-facet-postcard = { version = "0.44" }
+facet = { version = "0.46" }
+facet-core = { version = "0.46" }
+facet-format = { version = "0.47" }
+facet-reflect = { version = "0.46" }
+facet-testhelpers = { version = "0.46" }
+facet-json = { version = "0.46" }
+facet-postcard = { version = "0.46" }
 
 # CLI parsing
-figue = { version = "2" }
+figue = { version = "2.0.3" }
 
-# Roam RPC
-roam = { version = "7" }
-roam-types = { version = "7" }
-roam-core = { version = "7" }
-roam-stream = { version = "7" }
+# Vox RPC
+vox = { version = "0.4" }
 
 # Tracing
 tracing = "0.1"
@@ -63,14 +60,7 @@ opt-level = "s"
 inherits = "release"
 lto = "thin"
 
-# # Use local roam during v7 migration
-# [patch."https://github.com/bearcove/roam"]
-# roam = { path = "../roam/rust/roam" }
-# roam-types = { path = "../roam/rust/roam-types" }
-# roam-core = { path = "../roam/rust/roam-core" }
-# roam-stream = { path = "../roam/rust/roam-stream" }
-
-# # Uncomment to develop facet
+# Uncomment to develop facet
 # [patch."https://github.com/facet-rs/facet"]
 # facet = { path = "../facet/facet" }
 # facet-core = { path = "../facet/facet-core" }

--- a/crates/styx-lsp-ext/Cargo.toml
+++ b/crates/styx-lsp-ext/Cargo.toml
@@ -14,4 +14,4 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 [dependencies]
 facet.workspace = true
 styx-tree = { path = "../styx-tree", version = "3.0", features = ["facet"] }
-roam.workspace = true
+vox.workspace = true

--- a/crates/styx-lsp-ext/src/lib.rs
+++ b/crates/styx-lsp-ext/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 //! Protocol types for Styx LSP extensions.
 //!
-//! This crate defines the Roam service traits and types used for communication
+//! This crate defines the Vox service traits and types used for communication
 //! between the Styx LSP and external extensions that provide domain-specific
 //! intelligence (completions, hover, diagnostics, etc.).
 //!
@@ -9,7 +9,7 @@
 //!
 //! ```text
 //! ┌─────────────┐                      ┌─────────────────┐
-//! │  Styx LSP   │◄────── Roam ────────►│    Extension    │
+//! │  Styx LSP   │◄─────── Vox ────────►│    Extension    │
 //! │             │                      │   (e.g. dibs)   │
 //! │ implements  │                      │   implements    │
 //! │ StyxLspHost │                      │ StyxLspExtension│
@@ -21,7 +21,7 @@
 //!
 //! # Generated Types
 //!
-//! The `#[roam::service]` macro generates:
+//! The `#[vox::service]` macro generates:
 //! - `StyxLspExtensionClient` - Call extension methods from the LSP
 //! - `StyxLspExtensionDispatcher` - Dispatch incoming calls on the extension side
 //! - `StyxLspHostClient` - Call LSP methods from the extension
@@ -30,8 +30,8 @@
 use facet::Facet;
 use styx_tree::Value;
 
-// Re-export roam types needed by generated code and consumers
-pub use roam;
+// Re-export vox for generated code and consumers
+pub use vox;
 
 // =============================================================================
 // Service traits
@@ -40,7 +40,7 @@ pub use roam;
 /// Service implemented by LSP extensions.
 ///
 /// The Styx LSP calls these methods to request domain-specific intelligence.
-#[roam::service]
+#[vox::service]
 pub trait StyxLspExtension {
     /// Initialize the extension. Called once after spawn.
     async fn initialize(&self, params: InitializeParams) -> InitializeResult;
@@ -71,7 +71,7 @@ pub trait StyxLspExtension {
 ///
 /// Extensions can call these methods to request additional context about
 /// the document being edited.
-#[roam::service]
+#[vox::service]
 pub trait StyxLspHost {
     /// Get a subtree of the document at a path.
     async fn get_subtree(&self, params: GetSubtreeParams) -> Option<Value>;

--- a/crates/styx-lsp-test-schema/src/lib.rs
+++ b/crates/styx-lsp-test-schema/src/lib.rs
@@ -2,7 +2,7 @@
 //! Schema types for LSP extension test files.
 //!
 //! These types define the structure of `.styx` test files that exercise
-//! LSP extensions through real IPC (roam over stdio).
+//! LSP extensions through real IPC (vox over stdio).
 //!
 //! # Example Test File
 //!

--- a/crates/styx-lsp/Cargo.toml
+++ b/crates/styx-lsp/Cargo.toml
@@ -42,10 +42,8 @@ facet.workspace = true
 glob = "0.3"
 serde_json.workspace = true
 
-# LSP extensions (roam RPC)
-roam-core.workspace = true
-roam-stream.workspace = true
-roam-types.workspace = true
+# LSP extensions (vox RPC)
+vox.workspace = true
 
 # Extension protocol
 styx-lsp-ext = { path = "../styx-lsp-ext", version = "3.0" }

--- a/crates/styx-lsp/src/extensions.rs
+++ b/crates/styx-lsp/src/extensions.rs
@@ -24,9 +24,6 @@ use std::process::Stdio;
 use std::task::{Context, Poll};
 
 use facet_styx::LspExtensionConfig;
-use roam_core::BareConduit;
-use roam_stream::StreamLink;
-use roam_types::MessageFamily;
 pub use styx_lsp_ext::StyxLspExtensionClient;
 use styx_lsp_ext::{
     GetDocumentParams, GetSchemaParams, GetSourceParams, GetSubtreeParams, OffsetToPositionParams,
@@ -38,6 +35,7 @@ use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::RwLock;
 use tower_lsp::lsp_types::Url;
 use tracing::{debug, info, warn};
+use vox::transport::tcp::StreamLink;
 
 use crate::config::{self, StyxUserConfig};
 use crate::schema_validation::resolve_schema;
@@ -95,7 +93,7 @@ pub struct ExtensionManager {
     documents: DocumentMap,
 }
 
-/// A spawned extension process with roam connection.
+/// A spawned extension process with vox connection.
 struct Extension {
     /// The child process.
     #[allow(dead_code)]
@@ -103,7 +101,7 @@ struct Extension {
     /// Extension config from the schema.
     #[allow(dead_code)]
     config: LspExtensionConfig,
-    /// Roam client for making calls.
+    /// Vox client for making calls.
     client: StyxLspExtensionClient,
 }
 
@@ -199,7 +197,7 @@ impl ExtensionManager {
         extensions.get(schema_id).map(|ext| ext.client.clone())
     }
 
-    /// Spawn an extension process, establish roam connection, and initialize it.
+    /// Spawn an extension process, establish vox connection, and initialize it.
     async fn spawn_extension(
         &self,
         schema_id: &str,
@@ -229,13 +227,9 @@ impl ExtensionManager {
             })
             .ok()?;
 
-        // Take stdin/stdout for roam communication
+        // Take stdin/stdout for vox communication
         let stdin = process.stdin.take()?;
         let stdout = process.stdout.take()?;
-
-        // Wrap in length-prefix framing for roam
-        let link = StreamLink::new(stdout, stdin);
-        let conduit = BareConduit::<MessageFamily, _>::new(link);
 
         // Create host dispatcher for extension callbacks
         let host_impl = StyxLspHostImpl {
@@ -243,17 +237,18 @@ impl ExtensionManager {
         };
         let dispatcher = StyxLspHostDispatcher::new(host_impl);
 
-        // Initiate roam session (LSP is the initiator)
-        let (client, _session_handle) = roam_core::initiator(conduit)
-            .establish::<StyxLspExtensionClient>(dispatcher)
+        // Initiate vox session (LSP is the initiator)
+        let client = vox::initiator_on(StreamLink::new(stdout, stdin), vox::TransportMode::Bare)
+            .on_connection(dispatcher)
+            .establish::<StyxLspExtensionClient>()
             .await
             .map_err(|e| {
-                warn!(command, error = %e, "Failed roam handshake with extension");
+                warn!(command, error = %e, "Failed vox handshake with extension");
                 e
             })
             .ok()?;
 
-        debug!(command, "Roam session established with extension");
+        debug!(command, "Vox session established with extension");
         let init_result = client
             .initialize(styx_lsp_ext::InitializeParams {
                 styx_version: env!("CARGO_PKG_VERSION").to_string(),

--- a/crates/styx-lsp/src/testing/harness.rs
+++ b/crates/styx-lsp/src/testing/harness.rs
@@ -1,7 +1,7 @@
 //! Integration test harness for LSP extensions.
 //!
 //! This harness spawns extension binaries as subprocesses and communicates
-//! with them over roam (COBS-framed protocol over stdio), exactly like the
+//! with them over vox (length-prefix framing over stdio), exactly like the
 //! real Styx LSP does.
 //!
 //! # Example
@@ -26,14 +26,12 @@ use std::collections::HashMap;
 use std::process::Stdio;
 use std::sync::Arc;
 
-use roam_core::BareConduit;
-use roam_stream::StreamLink;
-use roam_types::MessageFamily;
 use styx_cst::parse;
 use styx_tree::Value;
 use tokio::process::{Child, Command};
 use tokio::sync::RwLock;
 use tower_lsp::lsp_types::Url;
+use vox::transport::tcp::StreamLink;
 
 use crate::extensions::StyxLspHostImpl;
 use crate::server::{DocumentMap, DocumentState};
@@ -100,7 +98,7 @@ type CursorMap = Arc<RwLock<HashMap<String, CursorInfo>>>;
 
 /// Integration test harness for LSP extensions.
 ///
-/// Spawns an extension binary and communicates via roam over stdio,
+/// Spawns an extension binary and communicates via vox over stdio,
 /// using the real `StyxLspHostImpl` from the LSP server.
 pub struct TestHarness {
     /// The spawned child process.
@@ -134,9 +132,6 @@ impl TestHarness {
         let stdin = process.stdin.take().ok_or(HarnessError::NoStdin)?;
         let stdout = process.stdout.take().ok_or(HarnessError::NoStdout)?;
 
-        let link = StreamLink::new(stdout, stdin);
-        let conduit = BareConduit::<MessageFamily, _>::new(link);
-
         let documents: DocumentMap = Arc::new(RwLock::new(HashMap::new()));
         let cursors: CursorMap = Arc::new(RwLock::new(HashMap::new()));
 
@@ -144,9 +139,10 @@ impl TestHarness {
         let host = StyxLspHostImpl::new(documents.clone());
         let dispatcher = StyxLspHostDispatcher::new(host);
 
-        // Initiate roam session (we're the initiator, like the real LSP)
-        let (client, _session_handle) = roam_core::initiator(conduit)
-            .establish::<StyxLspExtensionClient>(dispatcher)
+        // Initiate vox session (we're the initiator, like the real LSP)
+        let client = vox::initiator_on(StreamLink::new(stdout, stdin), vox::TransportMode::Bare)
+            .on_connection(dispatcher)
+            .establish::<StyxLspExtensionClient>()
             .await
             .map_err(|e| HarnessError::HandshakeFailed(e.to_string()))?;
 

--- a/crates/styx-lsp/src/testing/mod.rs
+++ b/crates/styx-lsp/src/testing/mod.rs
@@ -1,7 +1,7 @@
 //! Integration test harness and runner for LSP extensions.
 //!
 //! This module provides tools for testing LSP extensions through real IPC
-//! (roam over stdio), using the actual `StyxLspHostImpl` implementation.
+//! (vox over stdio), using the actual `StyxLspHostImpl` implementation.
 //!
 //! # Quick Start
 //!


### PR DESCRIPTION
## Summary

Migrates `styx-lsp-ext` and `styx-lsp` from the `roam` RPC framework to `vox` (its successor). Also bumps `facet` from 0.44 to 0.46 and `figue` from 2.0.0 to 2.0.3 to match what vox requires.

## Changes

**Cargo.toml (workspace):**
- `roam / roam-types / roam-core / roam-stream` → `vox = "0.4"`
- `facet* = "0.44"` → `"0.46"` (facet-format → `"0.47"`)
- `figue = "2"` → `"2.0.3"`

**styx-lsp-ext:**
- `#[roam::service]` → `#[vox::service]`
- `pub use roam` → `pub use vox`

**styx-lsp:**
- Session setup: `BareConduit + roam_core::initiator(conduit).establish::<Client>(dispatcher)` → `vox::initiator_on(link, TransportMode::Bare).on_connection(dispatcher).establish::<Client>()`
- Same change in both `extensions.rs` and `testing/harness.rs`
